### PR TITLE
add missing dependency to PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,13 +1,14 @@
 pkgname=goldwarden
 pkgver=0.1.9
-pkgrel=1
+pkgrel=2
 pkgdesc='A feature-packed Bitwarden compatible desktop integration'
 arch=('x86_64')
 url="https://github.com/quexten/$pkgname"
 license=('MIT')
-makedepends=('go' 'libfido2' 'gcc' 'wayland' 'libx11' 'libxkbcommon' 'libxkbcommon-x11' 'libxcursor' 'base-devel' 'vulkan-headers' 'egl-wayland')
+depends=('libfido2')
+makedepends=('go' 'gcc' 'wayland' 'libx11' 'libxkbcommon' 'libxkbcommon-x11' 'libxcursor' 'base-devel' 'vulkan-headers' 'egl-wayland')
 source=("$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('7d38db887437a58758e5f183d4951cf7c4d1b099f37ff6f5e95fb98735634983')
+sha256sums=('57555dab4afd4fc60785e8ad34f41932988b4cd2ce130daaa719625a0e455481')
 
 prepare(){
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
When trying to run `goldwarden` after installing it from the AUR, I had the following error:

```bash
$ goldwarden
goldwarden: error while loading shared libraries: libfido2.so.1: cannot open shared object file: No such file or directory
```
I fixed it by listing `libfido2` as a dependency in the package.

If this also applies to other `makedepends`, I would be glad to update this PR, but as I am only using this fine piece of software for biometric authentication, I didn't encounter any further issues.

Maybe you can verify this for the others, @quexten ?

PS: I also updated the `sha256sum` string to the value from the AUR PKGBUILD. :wink: 