### PR TITLE
Properly forward missing pinentry errors

### DIFF
--- a/agent/systemauth/pinentry/pinentry.go
+++ b/agent/systemauth/pinentry/pinentry.go
@@ -42,8 +42,7 @@ func GetPassword(title string, description string) (string, error) {
 		return externalPinentry.GetPassword(title, description)
 	}
 
-	// return "", errors.New("Not implemented")
-	return password, nil
+	return password, err
 }
 
 func GetApproval(title string, description string) (bool, error) {
@@ -56,6 +55,5 @@ func GetApproval(title string, description string) (bool, error) {
 		return externalPinentry.GetApproval(title, description)
 	}
 
-	// return true, errors.New("Not implemented")
-	return approval, nil
+	return approval, err
 }


### PR DESCRIPTION
Before running the following command without pinentry in PATH resulted in: Login failed: Could not sync vault: decrypt: MAC mismatch

With this change the error is properly forwarded and displayed $ ./goldwarden vault login --email me@example.com
Login failed: exec: "pinentry": executable file not found in $PATH