### PR TITLE
Fix more error handling

### DIFF
--- a/agent/actions/login.go
+++ b/agent/actions/login.go
@@ -34,7 +34,8 @@ func handleLogin(msg messages.IPCMessage, cfg *config.Config, vault *vault.Vault
 	var masterKey crypto.MasterKey
 	var masterpasswordHash string
 
-	if secret, err := cfg.GetClientSecret(); err == nil && secret != "" {
+	var secret string // don't shadow err in the next line
+	if secret, err = cfg.GetClientSecret(); err == nil && secret != "" {
 		actionsLog.Info("Logging in with client secret")
 		token, masterKey, masterpasswordHash, err = bitwarden.LoginWithApiKey(ctx, req.Email, cfg, vault)
 	} else if req.Passwordless {

--- a/agent/vault/vault.go
+++ b/agent/vault/vault.go
@@ -149,9 +149,9 @@ func (vault *Vault) isSSHKey(cipher models.Cipher) bool {
 			cipherID := cipher.ID.String()
 			if cipher.OrganizationID != nil {
 				orgID := cipher.OrganizationID.String()
-				vaultLog.Error("Failed to decrypt field name with on cipher "+cipherID+" in organization "+orgID, err.Error())
+				vaultLog.Error("Failed to decrypt field name with on cipher %s in organization %s: %s", cipherID, orgID, err.Error())
 			} else {
-				vaultLog.Error("Failed to decrypt field name with on cipher "+cipherID, err.Error())
+				vaultLog.Error("Failed to decrypt field name with on cipher %s: %s", cipherID, err.Error())
 			}
 			continue
 		}


### PR DESCRIPTION
The first error tried to log into the server without providing a password, resulting in a 401.

In the second error the string got not properly formatted and the error was printed plain:

```
[ERR] [01:02] [Goldwarden > Vault] >>> Failed to decrypt field name with on cipher 3b1e00e0-e2bf-40e8-9864-e35611f9d8ce%!(EXTRA string=decrypt: cipher of unsupported type '\x00')
```