### PR TITLE
Use /usr/bin/env for binaries

### DIFF
--- a/browserbiometrics/manifests.go
+++ b/browserbiometrics/manifests.go
@@ -22,7 +22,7 @@ const templateChrome = `{
 	]
   }`
 
-const proxyScript = `#!/bin/bash
+const proxyScript = `#!/usr/bin/env bash
 
 # Check if the "com.quexten.Goldwarden" Flatpak is installed
 if flatpak list | grep -q "com.quexten.Goldwarden"; then

--- a/gui/src/gui/settings.py
+++ b/gui/src/gui/settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import sys
 import gi
 gi.require_version('Gtk', '4.0')

--- a/gui/src/linux/main.py
+++ b/gui/src/linux/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import time
 import subprocess
 from tendo import singleton


### PR DESCRIPTION
to make them easily work on almost all platforms

NixOS does not have /usr/bin/bash or python but it has /usr/bin/env to find those binaries in PATH. Also changed python to python3 as python is originally pyton2.