### PR TITLE
fix: pin macos-13 as os for building amd64 binary

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -77,7 +77,7 @@ jobs:
         path: ./goldwarden_linux_x86
 
   build_macos_x86_64:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -90,13 +90,13 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - name: Fido2
         run: brew install libfido2
-      - name: Build 
+      - name: Build
         run: go build -o "goldwarden_macos_x86_64" -v .
       - uses: actions/upload-artifact@v3
         with:
           name: goldwarden-macos_x86_64
           path: ./goldwarden_macos_x86_64
-  
+
   build_macos_aarch64:
     runs-on: macos-14
     steps:
@@ -111,13 +111,13 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - name: Fido2
         run: brew install libfido2
-      - name: Build 
+      - name: Build
         run: go build -o "goldwarden_macos_aarch64" -v .
       - uses: actions/upload-artifact@v3
         with:
           name: goldwarden-macos_aarch64
-          path: ./goldwarden_macos_aarch64  
-    
+          path: ./goldwarden_macos_aarch64
+
   build_windows_x86_64:
     runs-on: windows-latest
     steps:
@@ -132,13 +132,13 @@ jobs:
         run: |
           scoop bucket add keys.pub https://github.com/keys-pub/scoop-bucket
           scoop install libfido2
-      - name: Build 
+      - name: Build
         run: go build -o "goldwarden_windows_x86_64.exe" -v .
       - uses: actions/upload-artifact@v3
         with:
           name: goldwarden-windows_x86_64.exe
           path: ./goldwarden_windows_x86_64.exe
-  
+
   build_windows_aarch64:
     runs-on: windows-latest
     steps:
@@ -148,7 +148,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Build 
+      - name: Build
         run: set GOARCH=arm64 && go build -tags nofido2 -o "goldwarden_windows_aarch64.exe" -v .
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
I've been looking at your CI build config because I am currently trying to figure out a multi-arch go build that uses libfido2 and spotted one subtle issue that could affect the amd64 build of future versions in this project.

The config uses "macos-latest" os for building the x86_64 version which currently defaults to "macos-14". This os seems to create only arm64 binaries (I don't know too much about mac architecture). It seems that at the time of the last release the default was "macos-12" (checked the wayback machine on the github docs). So the increase of the default would probably cause the x86_64 binaries in the next release to actually be arm64. Pinning the version to "macos-13" seems to fix that.