### PR TITLE
fixed broken PKGBUILD

### DIFF
--- a/.github/workflows/PKGBUILD
+++ b/.github/workflows/PKGBUILD
@@ -12,7 +12,7 @@ sha256sums=('57555dab4afd4fc60785e8ad34f41932988b4cd2ce130daaa719625a0e455481')
 
 prepare(){
   cd "$pkgname-$pkgver"
-  mkdir -p build/
+  mkdir -p build/ cmd/
 }
 
 build() {


### PR DESCRIPTION
closes #205 

tested, and confirmed that it builds properly with this patch. 

AUR pkg guidelines say that you should increment the 'pkgrel' number in the PKGBUILD whenever you apply a fix - but I'm not sure if that would interfere with your CI pipeline!

credit goes to lamelos on the AUR forums!