### PR TITLE
fix: autotypeing with libportal

### DIFF
--- a/gui/src/services/autotype/libportal_autotype.py
+++ b/gui/src/services/autotype/libportal_autotype.py
@@ -2,4 +2,4 @@ from ..goldwarden import autotype
 
 def autotype_libportal(text):
     print("autotypeing with libportal")
-    goldwarden.autotype(text)
+    autotype(text)


### PR DESCRIPTION
Fixes #229. Tested via the Flathub package.