### PR TITLE
Readme: update logo filename (hotfix for https://github.com/quexten/goldwarden/pull/293)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/quexten/goldwarden/main/gui/goldwarden.svg" width=200>
+<img src="https://raw.githubusercontent.com/quexten/goldwarden/main/gui/com.quexten.Goldwarden.svg" width=200>
 
 # Goldwarden
 


### PR DESCRIPTION
Commit 0dd6ac11889ad195c99e8f708d6c3c2db293163b ("gui: rename logo's filename to icon name") caused the filename of the logo to change. All instances of the filename were also renamed, besides in Readme.md.

Fix it here too.

Fixes: 0dd6ac11889ad195c99e8f708d6c3c2db293163b ("gui: rename logo's filename to icon name")
Reported-by: @ozmodeuz