### PR TITLE
Remove checking for parent / grandparent process

### DIFF
--- a/cli/agent/systemauth/systemauth.go
+++ b/cli/agent/systemauth/systemauth.go
@@ -55,7 +55,7 @@ func (s *SessionStore) CreateSession(pid int, parentpid int, grandparentpid int,
 
 func (s *SessionStore) verifySession(ctx sockets.CallingContext, sessionType SessionType) bool {
 	for _, session := range s.Store {
-		if session.ParentPid == ctx.ParentProcessPid && session.GrandParentPid == ctx.GrandParentProcessPid && session.sessionType == sessionType {
+		if session.sessionType == sessionType {
 			if session.Expires.After(time.Now()) {
 				return true
 			}

--- a/cli/agent/systemauth/systemauth.go
+++ b/cli/agent/systemauth/systemauth.go
@@ -56,8 +56,11 @@ func (s *SessionStore) CreateSession(pid int, parentpid int, grandparentpid int,
 func (s *SessionStore) verifySession(ctx sockets.CallingContext, sessionType SessionType) bool {
 	for _, session := range s.Store {
 		if session.sessionType == sessionType {
-			if session.Expires.After(time.Now()) {
-				return true
+			// only check for ancestor if the session is not a ssh session
+			if sessionType == SSHKey || (session.ParentPid == ctx.ParentProcessPid && session.GrandParentPid == ctx.GrandParentProcessPid) {
+				if session.Expires.After(time.Now()) {
+					return true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is just a proposal, where is it needed to check for parent & grand parent process (for cache)?

This is is different than the standard `ssh-agent` process where `ssh-add ~/.ssh/id_xxx` will adds the key to memory, and then it works in other terminals (I don't think it checks for parent process).

I understand that perhaps this approach allows for more fine-grain control of prompting request. However, it doesn't quite works right most of the time. E.g.

1. In plain `ssh my_host` the cache works well. But as soon as there are jump-host the cache no longer works
	- i.e., If your `~/.ssh/config` has a `host_b` that jumps through `host_a`, it prompts for approval every time (probably because it spawns another ssh process, which makes `parentProcess` having different PID)
	- Reducing to JUST checking for grandParentProcess PID works, but then it fails again if we ssh to `host_c` via `host_b` via `host_a`, and so on.
2. My git pull does not cache as well, where in the `goldwarden` log it shows
		```
		[INF] [...] [Goldwarden > SSH] >>> SSH Agent connection from fish>git>git
		```
		so perhaps the git is using some subprocess, which causes checking of parent process fails
3. Again, even if we revert to checking for grandParentProcess, the above fails once we are using some wrapper process. I'm using [yadm](https://github.com/TheLocehiliosan/yadm) to manage my dotfile (which wraps git), and in `goldwarden` the process shows
		```
		[INF] [...] [Goldwarden > SSH] >>> SSH Agent connection from yadm>git>git
		```
		i.e., Checking for grandParentProcess will no longer cache the session.
4. Essentially, the intended cache logic can **probably** works if we walk the process hierarchical structure by getting their parents until we reach some interactive terminal, but I reckon that'd be too fragile.
	

