### PR TITLE
Fix: Use pinentry-mac as pinentry binary on macOS for approvals

### DIFF
--- a/cli/agent/systemauth/pinentry/go-pinentry.go
+++ b/cli/agent/systemauth/pinentry/go-pinentry.go
@@ -9,11 +9,16 @@ import (
 	"github.com/twpayne/go-pinentry"
 )
 
-func getPassword(title string, description string) (string, error) {
+func getBinaryClientOption() (clientOption pinentry.ClientOption) {
 	binaryClientOption := pinentry.WithBinaryNameFromGnuPGAgentConf()
 	if runtime.GOOS == "darwin" {
 		binaryClientOption = pinentry.WithBinaryName("pinentry-mac")
 	}
+	return binaryClientOption
+}
+
+func getPassword(title string, description string) (string, error) {
+	binaryClientOption := getBinaryClientOption()
 
 	client, err := pinentry.NewClient(
 		binaryClientOption,
@@ -49,8 +54,10 @@ func getApproval(title string, description string) (bool, error) {
 		return true, nil
 	}
 
+	binaryClientOption := getBinaryClientOption()
+
 	client, err := pinentry.NewClient(
-		pinentry.WithBinaryNameFromGnuPGAgentConf(),
+		binaryClientOption,
 		pinentry.WithGPGTTY(),
 		pinentry.WithTitle(title),
 		pinentry.WithDesc(description),


### PR DESCRIPTION
I couldn't approve SSH Agent requests on macOS, it would just automatically deny any request.
This seems to be fixing the issue.